### PR TITLE
tabAgeForAutomaticClosing minimum update

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -20,7 +20,7 @@ const settings = {
 	},
 	"autoclosetabs.tabAgeForAutomaticClosing": {
 		type: "number",
-		minimum: 1,
+		minimum: 0.01,
 		default: 12,
 	},
 };


### PR DESCRIPTION
This extension would be even better if the tabAgeForAutomaticClosing could be set to less than an hour!
Allowing a minimum such as 0.01 (≈1 minute) would be awesome.

----
As for why, I've been currently experiencing a lot of issues in huge mono-repos in vscode keeping few tabs open tends to easy my pain. Keeping too many tabs open causes TS services, lists, and other background features consume all my RAM until it stops working and closing them won't work, too late kind of situation

The extension is great, but one hour is still way too long for my use case.
From what I saw in the code, there doesn't seem to be a hard reason for the 1-hour minimum anyway.

I’ll probably be setting mine to ~5 minutes.