### PR TITLE
Derive unique ID for webview tabs from stable Tab object identity

### DIFF
--- a/src/web/autoclosetabs.ts
+++ b/src/web/autoclosetabs.ts
@@ -35,6 +35,29 @@ let closedTabs: {
 
 let webview: vscode.WebviewPanel | undefined;
 
+/**
+ * Webview tab inputs expose no URI, and several webview tabs can share the
+ * same view type and label, so an ID cannot be derived from the input alone.
+ * However, VS Code keeps the identity of a Tab object stable for the
+ * lifetime of the tab, so we can assign our own number to each webview tab.
+ * These numbers are not persisted: after a window reload, webview tabs
+ * simply start aging from zero again.
+ */
+const webviewTabNumbers = new WeakMap<vscode.Tab, number>();
+let nextWebviewTabNumber = 1;
+
+const getWebviewTabNumber = (tab: vscode.Tab): number => {
+	const existingNumber = webviewTabNumbers.get(tab);
+
+	if (existingNumber !== undefined) {
+		return existingNumber;
+	}
+
+	const number = nextWebviewTabNumber++;
+	webviewTabNumbers.set(tab, number);
+	return number;
+};
+
 const getTabId = (tab: vscode.Tab): string | undefined => {
 	const input = tab.input;
 
@@ -55,7 +78,7 @@ const getTabId = (tab: vscode.Tab): string | undefined => {
 	}
 
 	if (input instanceof vscode.TabInputWebview) {
-		return `webview:${input.viewType}:${tab.label}`;
+		return `webview:${input.viewType}:${getWebviewTabNumber(tab)}`;
 	}
 
 	// Tab might be a terminal, or an unknown kind of tab


### PR DESCRIPTION
Webview tab inputs expose no URI, so an ID derived from view type and label collide when several webviews share both.

VS Code guarantees that a Tab’s frozen apiObject keeps a stable identity for the lifetime of the tab (see [code comment in `ExtHostEditorTabGroup`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/common/extHostEditorTabs.ts#L165C1-L165C73)), so assign each webview tab a number via a WeakMap and use it in the tab ID instead of the label. The numbers are not persisted; after a window reload webview tabs age from zero again.